### PR TITLE
Reduce number of allocations

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,165 @@
+package promise
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func BenchmarkNew(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		New(func(resolve func(interface{}), reject func(error)) {
+			resolve(nil)
+		})
+	}
+}
+
+func BenchmarkThen(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var promise = New(func(resolve func(interface{}), reject func(error)) {
+			resolve(1 + 1)
+		})
+
+		promise.
+			Then(func(data interface{}) interface{} {
+				return data.(int) + 1
+			}).
+			Then(func(data interface{}) interface{} {
+				return nil
+			}).
+			Catch(func(err error) error {
+				return nil
+			})
+
+		promise.Await()
+	}
+}
+
+func BenchmarkCatch(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var promise = New(func(resolve func(interface{}), reject func(error)) {
+			reject(errors.New("very serious err"))
+		})
+
+		promise.
+			Catch(func(err error) error {
+				return nil
+			}).
+			Catch(func(err error) error {
+				return nil
+			})
+
+		promise.Then(func(data interface{}) interface{} {
+			return nil
+		})
+
+		promise.Await()
+	}
+}
+
+func BenchmarkAwait(b *testing.B) {
+	var promises = make([]*Promise, 10)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for x := 0; x < 10; x++ {
+
+			var promise = New(func(resolve func(interface{}), reject func(error)) {
+				resolve(time.Now())
+			})
+
+			promise.Then(func(data interface{}) interface{} {
+				return data.(time.Time).Add(time.Second).Nanosecond()
+			})
+
+			promises[x] = promise
+		}
+
+		var promise1 = Resolve("WinRAR")
+		var promise2 = Reject(errors.New("fail"))
+
+		for _, p := range promises {
+			p.Await()
+		}
+
+		promise1.Await()
+		promise2.Await()
+	}
+}
+
+func BenchmarkResolve(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var promise = Resolve(123).
+			Then(func(data interface{}) interface{} {
+				return data.(int) + 1
+			}).
+			Then(func(data interface{}) interface{} {
+				return nil
+			})
+
+		promise.Await()
+	}
+}
+
+func BenchmarkReject(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var promise = Reject(errors.New("rejected")).
+			Then(func(data interface{}) interface{} {
+				return data.(int) + 1
+			}).
+			Catch(func(err error) error {
+				return nil
+			})
+
+		promise.Await()
+	}
+}
+
+func BenchmarkAll(b *testing.B) {
+	var promises = make([]*Promise, 10)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for x := 0; x < 10; x++ {
+			if x == 8 {
+				promises[x] = Reject(errors.New("bad promise"))
+				continue
+			}
+
+			promises[x] = Resolve("All Good")
+		}
+
+		All(promises...).Await()
+	}
+}
+
+func BenchmarkAllSettled(b *testing.B) {
+	var promises = make([]*Promise, 10)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for x := 0; x < 10; x++ {
+			if x == 8 {
+				promises[x] = Reject(errors.New("bad promise"))
+				continue
+			}
+
+			promises[x] = Resolve("All Good")
+		}
+
+		AllSettled(promises...).Await()
+	}
+}
+
+func BenchmarkRace(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var p1 = Resolve("Promise 1")
+		var p2 = Resolve("Promise 2")
+
+		Race(p1, p2).Await()
+	}
+}


### PR DESCRIPTION
A bit of refactoring to reduce number of allocations
```
name          old time/op    new time/op    delta
New-4            374ns ± 5%     327ns ± 9%  -12.52%  (p=0.008 n=5+5)
Then-4           983ns ± 1%    1031ns ± 8%   +4.88%  (p=0.008 n=5+5)
Catch-4         1.02µs ± 2%    1.00µs ± 0%   -1.77%  (p=0.008 n=5+5)
Await-4         8.32µs ± 2%    7.69µs ± 1%   -7.58%  (p=0.008 n=5+5)
Resolve-4       1.01µs ± 0%    0.97µs ± 1%   -4.39%  (p=0.008 n=5+5)
Reject-4        1.00µs ± 1%    0.95µs ± 0%   -4.85%  (p=0.008 n=5+5)
All-4           9.94µs ± 1%    9.11µs ± 2%   -8.31%  (p=0.008 n=5+5)
AllSettled-4    11.8µs ± 2%    11.0µs ± 1%   -6.78%  (p=0.008 n=5+5)
Race-4          2.99µs ± 2%    2.79µs ± 1%   -6.61%  (p=0.008 n=5+5)

name          old alloc/op   new alloc/op   delta
New-4             168B ± 0%      160B ± 0%   -4.76%  (p=0.008 n=5+5)
Then-4            208B ± 0%      200B ± 0%   -3.66%  (p=0.008 n=5+5)
Catch-4           216B ± 0%      208B ± 0%   -3.53%  (p=0.000 n=5+4)
Await-4         2.58kB ± 0%    2.48kB ± 0%   -3.73%  (p=0.008 n=5+5)
Resolve-4         232B ± 0%      224B ± 0%   -3.45%  (p=0.008 n=5+5)
Reject-4          232B ± 0%      224B ± 0%   -3.62%  (p=0.008 n=5+5)
All-4           3.89kB ± 0%    3.46kB ± 0%  -11.11%  (p=0.008 n=5+5)
AllSettled-4    3.90kB ± 0%    3.43kB ± 0%  -11.98%  (p=0.000 n=5+4)
Race-4            977B ± 0%      953B ± 0%   -2.46%  (p=0.008 n=5+5)

name          old allocs/op  new allocs/op  delta
New-4             5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.008 n=5+5)
Then-4            8.00 ± 0%      6.00 ± 0%  -25.00%  (p=0.008 n=5+5)
Catch-4           8.00 ± 0%      6.00 ± 0%  -25.00%  (p=0.008 n=5+5)
Await-4           92.0 ± 0%      68.0 ± 0%  -26.09%  (p=0.008 n=5+5)
Resolve-4         8.00 ± 0%      6.00 ± 0%  -25.00%  (p=0.008 n=5+5)
Reject-4          8.00 ± 0%      6.00 ± 0%  -25.00%  (p=0.008 n=5+5)
All-4              118 ± 0%        80 ± 0%  -32.20%  (p=0.008 n=5+5)
AllSettled-4       123 ± 0%        84 ± 0%  -31.71%  (p=0.008 n=5+5)
Race-4            30.0 ± 0%      24.0 ± 0%  -20.00%  (p=0.008 n=5+5)
```