### PR TITLE
Promise Branching

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2018 Petr
+Copyright (c) 2020 Petr
+Copyright (c) 2020 Michael Orenstein
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ var p = promise.New(func(resolve func(interface{}), reject func(error)) {
 })
 
 // You may continue working with the result of 
-// a previous async operation.
-p.Then(func(data interface{}) interface{} {
+// a previous async operation. Calling .Then returns a new promise.
+var resultP = p.Then(func(data interface{}) interface{} {
   fmt.Println("The result is:", data)
   return data.(int) + 1
 })
@@ -53,7 +53,8 @@ p.Then(func(data interface{}) interface{} {
 // Callbacks can be added even after the success or failure of the asynchronous operation.
 // Multiple callbacks may be added by calling .Then or .Catch several times,
 // to be executed independently in insertion order.
-p.
+// Each call returns a new promise, allowing for branching chains of promises.
+var caughtP = p.
   Then(func(data interface{}) interface{} {
     fmt.Println("The new result is:", data)
     return nil
@@ -64,10 +65,17 @@ p.
   })
 
 // Since callbacks are executed asynchronously you can wait for them.
-p.Await()
+
+// Wait for the result
+resultP.Await()
+
+// Wait for the caught branch
+caughtP.Await()
 ```
 
 ## Methods
+
+All methods except `.Await()` return new promises allowing for branching logic.
 
 ### All
 

--- a/promise_test.go
+++ b/promise_test.go
@@ -95,7 +95,9 @@ func TestPromise_Catch(t *testing.T) {
 				t.Error("Error doesn't propagate")
 			}
 			return nil
-		}).Then(func(data interface{}) interface{} {
+		})
+
+	promise.Then(func(data interface{}) interface{} {
 		t.Error("Then triggered in .Catch test")
 		return nil
 	})

--- a/promise_test.go
+++ b/promise_test.go
@@ -95,9 +95,7 @@ func TestPromise_Catch(t *testing.T) {
 				t.Error("Error doesn't propagate")
 			}
 			return nil
-		})
-
-	promise.Then(func(data interface{}) interface{} {
+		}).Then(func(data interface{}) interface{} {
 		t.Error("Then triggered in .Catch test")
 		return nil
 	})


### PR DESCRIPTION
Closes #18

Every method except Await now returns a new Promise to allow for branching logic.

**This is a breaking API change.**

Where previously this would await the "Caught and Then'd" version of promise, it now branches into the caught branch and the "Then'd" branch.

```

	var promise = New(func(resolve func(interface{}), reject func(error)) {
		reject(errors.New("very serious err"))
	})

	promise.
		Catch(func(err error) error {
			if err.Error() == "very serious err" {
				return errors.New("dealing with err at this stage")
			}
			return nil
		}).
		Catch(func(err error) error {
			if err.Error() != "dealing with err at this stage" {
				t.Error("Error doesn't propagate")
			}
			return nil
		})
	
	promise.Then(func(data interface{}) interface{} {
		t.Error("Then triggered in .Catch test")
		return nil
	})

	promise.Await()

```

The functionality now is more similar to how the JS API works.

This would be the idiomatic way to write the above. The `promise` variable is the caught and "Then'd" promise.

```

	var promise = New(func(resolve func(interface{}), reject func(error)) {
		reject(errors.New("very serious err"))
	}).Catch(func(err error) error {
			if err.Error() == "very serious err" {
				return errors.New("dealing with err at this stage")
			}
			return nil
		}).
		Catch(func(err error) error {
			if err.Error() != "dealing with err at this stage" {
				t.Error("Error doesn't propagate")
			}
			return nil
		}).Then(func(data interface{}) interface{} {
		t.Error("Then triggered in .Catch test")
		return nil
	})

	promise.Await()

```
One of the tests was updated to reflect this, I didn't touch the other tests.

Allocations are obviously worse now that this copies all the time.
```
BenchmarkNew-12           	 3395116	       356 ns/op	     128 B/op	       3 allocs/op
BenchmarkThen-12          	  537918	      2036 ns/op	     568 B/op	      16 allocs/op
BenchmarkCatch-12         	  636610	      1836 ns/op	     576 B/op	      16 allocs/op
BenchmarkAwait-12         	  140638	      8473 ns/op	    3456 B/op	      99 allocs/op
BenchmarkResolve-12       	  462471	      2718 ns/op	     456 B/op	      13 allocs/op
BenchmarkReject-12        	  448644	      2656 ns/op	     464 B/op	      13 allocs/op
BenchmarkAll-12           	   84603	     15931 ns/op	    5905 B/op	     150 allocs/op
BenchmarkAllSettled-12    	   71997	     15515 ns/op	    5842 B/op	     149 allocs/op
BenchmarkRace-12          	  304389	      3860 ns/op	    1408 B/op	      37 allocs/op
```