### PR TITLE
Make Promise.Then and Promise.Catch propagate result properly

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,3 +15,5 @@
 * **[Michael Orenstein](https://github.com/Mike-Dax)**
 
 * **[Aleksey Myasnikov](https://github.com/asmyasnikov)**
+
+* **[Elvis Pranskevichus](https://github.com/elprans)**

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Install
 
-    $ go get -u github.com/chebyrash/promise
+    $ go get -u github.com/elprans/go-promise
 
 ## Introduction
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chebyrash/promise
+module github.com/elprans/go-promise
 
 go 1.18
 

--- a/promise_test.go
+++ b/promise_test.go
@@ -21,8 +21,8 @@ func TestPromise_Then(t *testing.T) {
 	p1 := New(func(resolve func(string), reject func(error)) {
 		resolve("Hello, ")
 	})
-	p2 := Then(p1, func(data string) string {
-		return data + "world!"
+	p2 := Then(p1, func(data string) (string, error) {
+		return data + "world!", nil
 	})
 
 	val, err := p1.Await()
@@ -38,9 +38,9 @@ func TestPromise_Catch(t *testing.T) {
 	p1 := New(func(resolve func(any), reject func(error)) {
 		reject(expectedError)
 	})
-	p2 := Then(p1, func(data any) any {
+	p2 := Then(p1, func(data any) (any, error) {
 		t.Fatal("should not execute Then")
-		return nil
+		return nil, nil
 	})
 
 	val, err := p1.Await()


### PR DESCRIPTION
Currently, `Then` and `Catch` are declared to return a single value,
which makes raising errors in `Then` or recovering in `Catch`
impossible.  Fix this by adjusting the signature of `Then` and `Catch`
handlers to accept functions returning a pair of values.  An error
returned from `Then` is then passed to the next `Catch`, and if `Catch`
returns a non-error value, it is taken as the resolution for the promise
chain.  This conforms to the behavior of JavaScript Promise objects.